### PR TITLE
Update CV with anonymized client names

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,18 +1,140 @@
-# My CV
+# Alexandr Harabara CV
 
-Welcome to my CV page. This is a sample GitHub Pages site.
+## Career Summary
 
-## About Me
+With a robust background in PHP development and a strong focus on building scalable web applications and APIs, Alexandr brings extensive expertise in a wide range of technologies and tools. His experience spans mentoring colleagues, conducting internships for students, and interviewing over 70 candidates across Moldova, Romania, Morocco, and Vietnam. Alexandr is proficient in PHP, Symfony, Laravel, API Platform, Docker, AWS Services, GraphQL, and numerous other technologies, and has successfully contributed to industries such as camping services, luxury cars premium services, product company storage and sales management, payment platforms, flight and hotel booking, and e-commerce.
 
-Write something about yourself here.
+## Summary of Qualifications
 
-## Experience
+Experienced in:
 
-- Job 1
-- Job 2
+- PHP
+- Symfony/Slim
+- API Platform
+- Laravel/Lumen
+- Bref
+- RoadRunner
+- PHPUnit
+- JS/TS
+- MySQL
+- PostgreSQL
+- SQLite
+- Redis
+- DynamoDB
+- OpenSearch
+- AWS Services
+- AWS CDK
+- SST (sst.dev)
+- GitHub Action
+- Gitlab CI/CD
+- Jenkins
+- Docker
+- Docker Compose
+- Vagrant
+- VirtualBox
+- WSL 1/2
+- Linux, Mac, Win
+- GraphQL
+- OpenAPI/Swagger
+- JSON-RPC
+- SOAP
+- OIDC/OAuth
+- Hexagonal architecture
+- DDD
+- LLM’s, OCR, ALPR
+
+## Career History
+
+### Pentalog - Camping Services Platform, Chisinau, Moldova — 2024–now
+**PHP Backend developer, Team Leader**
+- The project is a website that gives the possibility to search through ~11000 campsites by preferred criteria.
+- Jamstack-like architecture, Symfony with API Platform on AWS Lambda API, React SPA for Backoffice, Next.js for Frontend.
+- Development of GraphQL API based on Symfony and API platform.
+- Development of infrastructure using SST and AWS CDK.
+- Teammates support, consulting, mentoring.
+- Technologies: Symfony on Lambda (Bref), API Platform, GraphQL, Docker, AWS CDK, SST, Typescript, DynamoDB, OpenSearch, GitHub Actions, Aurora Serverless, API Gateway.
+- Team size: 8.
+- Agile, Scrum.
+
+### Pentalog - Luxury Car Concierge Service, Chisinau, Moldova — 2022–2023
+**PHP Backend developer**
+- Concierge Service for Exceptional Cars.
+- Client-Server Architecture, Symfony on AWS EC2 for Backoffice and API, React Native for mobile.
+- Development of Symfony Backoffice (CRM) and GraphQL API for car caretakers.
+- Accountable for the deliverables.
+- Technologies: PHP, Symfony, Sonata, GraphQL, Docker, AWS Cognito, AWS CodeBuild, AWS CodePipeline, AWS Pinpoint, AWS SQS, AWS Cloudwatch.
+- Team size: 5.
+- Agile, Scrum.
+
+### Pentalog - Cryptocurrency Platform, Chisinau, Moldova — 2021–2022
+**PHP Backend Developer**
+- Cryptocurrency Wallet and Trading Services.
+- Microservices Architecture, Blockchain.
+- Development of debit card issuance and transactions.
+- Technologies: PHP, Laravel, Golang, REST, Kafka, Docker, AWS, Redis, Datadog, Roadrunner, Gitlab, PHP 7-8.1, SQS, Graylog, Sentry, Laravel 7-9.1, OpenAPI/Swagger.
+- Team size: 16.
+- Agile, Scrum.
+
+### Pentalog - Payment Platform, Chisinau, Moldova — 2019–2021
+**PHP Developer**
+- The platform API can be used to build apps that connect to the payment platform system, place and manage orders, manage subscriptions and customers, create, update and extract product catalog and pricing information, manage partner accounts, automate back-end operations.
+- Technologies: Docker, Slim framework, Vagrant, Symfony, PHP, Docker Compose, Hexagonal architecture, MySQL, DDD, Microservices, OpenAPI/Swagger.
+- API development and maintenance.
+- Performance optimization.
+- SOAP, REST and JSON-RPC web services development, maintenance and integration.
+- Team size: 3.
+- Agile, Scrum.
+
+### Pentalog - Geospatial Project, Chisinau, Moldova — 2018–2019
+**PHP Developer**
+- Development of a web application based on GeoServer for a region in France.
+- Technologies: Docker, Twig, Symfony, PHP, Docker Compose, JavaScript, MySQL, PostgreSQL, Doctrine.
+- Subject analysis, estimations, proposal of technical solutions.
+- Configuration and finetuning of GeoServer.
+- Performance optimization, bug fixing and maintenance.
+- Team size: 8.
+- Agile, Scrum.
+
+### Best4u International, Chisinau, Moldova — 2017–2018
+**WordPress / Magento / Laravel Developer**
+- Magento 1 and 2 online shops, WordPress Websites, WooCommerce, Laravel CRM systems.
+- Technologies: Docker, GIT, Composer, Magento 1 and 2, WordPress, Laravel, MVC, PHP, Linux Server.
+- Software development according to the provided requirements.
+- Maintenance of old projects, security patches, git versioning of old projects.
+- Team size: 2–6.
+- Scrum, Waterfall.
+
+### System Capital Management, Balti, Moldova — 2016–2017
+**PHP Full Stack Developer**
+- Flight and hotel booking and search system.
+- Designing of a new custom framework.
+- Integration of 3rd party APIs (SOAP, JSON-RPC, REST).
+- Import of big sets of data from different sources (XSL, XML, CSV, JSON).
+- Optimization of search process, database queries and search algorithms.
+- Team size: 6.
+- Kanban.
+
+### System Capital Management, Balti, Moldova — 2016
+**PHP Backend Developer**
+- Company storage and sales management system.
+- MVC architecture, custom source code.
+- Database and code performance optimization.
+- Team size: 6.
+- Kanban.
+
+### Freelance, Balti, Moldova — 2015–2016
+**PHP / CMS Developer**
+- Developing CMS plugins.
+- Website development.
+- Performance optimization.
 
 ## Education
 
-- School 1
-- School 2
+**"Alecu Russo" State University**, Balti, Republic of Moldova — 2014–2017
+- Bachelor's Degree in Computer Science.
 
+## Languages
+
+- Russian (native)
+- English (advanced)
+- Romanian (advanced)


### PR DESCRIPTION
## Summary
- replace client company names in Pentalog section with generic descriptions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856309da4c0832e96e94869fc2794a9